### PR TITLE
Improve droplet animation timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Ripple</title>
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Shizuru&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200;400&display=swap" rel="stylesheet">
     <link rel="icon" href="ripple.png">
     <!-- 外部CSS -->
     <link rel="stylesheet" href="style.css">
@@ -16,8 +16,8 @@
     <div class="card">
         <!-- ロゴ画像。logo.svg または png を同じディレクトリに置く -->
         <img src="r_ripple.png" alt="店舗ロゴ" class="logo" />
-        <h1 class="store-name">お客様１人１人とのお時間を大切にする<br>
-            プライベートサロン</h1>
+        <h2 class="store-name">お客様１人１人とのお時間を大切にする<br>
+            プライベートサロン</h2>
         <p class="tagline">
             hair design space <br>Ripple
         </p>

--- a/script.js
+++ b/script.js
@@ -2,47 +2,66 @@
 window.addEventListener('DOMContentLoaded', () => {
   const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const title = document.querySelector('.store-name');
-  if (prefersReduced) {
-    title.style.opacity = 1;
-    title.style.filter = 'none';
-    return;
+  const card = document.querySelector('.card');
+  const logo = document.querySelector('.logo');
+
+  function runAnimation() {
+    if (prefersReduced) {
+      card.style.opacity = 1;
+      title.style.opacity = 1;
+      title.style.filter = 'none';
+      return;
+    }
+
+    document.querySelectorAll('.drop, .ripple').forEach(el => el.remove());
+
+    card.style.opacity = 0;
+
+    const drop = document.createElement('div');
+    drop.className = 'drop';
+    document.body.appendChild(drop);
+
+    const ripple = document.createElement('div');
+    ripple.className = 'ripple';
+    document.body.appendChild(ripple);
+
+    anime.timeline()
+      .add({
+        targets: drop,
+        translateY: ['-220', '65vh'],
+        duration: 1600,
+        easing: 'easeOutBounce'
+      })
+      .add({
+        targets: drop,
+        opacity: [1, 0],
+        duration: 400,
+        easing: 'linear'
+      })
+      .add({
+        targets: ripple,
+        scale: [0, 60],
+        opacity: [0.6, 0],
+        duration: 1500,
+        easing: 'easeOutQuad',
+        offset: '-=1200'
+      })
+      .add({
+        targets: card,
+        opacity: [0, 1],
+        duration: 500,
+        easing: 'easeOutQuad'
+      })
+      .add({
+        targets: title,
+        opacity: [0, 1],
+        filter: ['blur(10px)', 'blur(0px)'],
+        duration: 800,
+        easing: 'easeOutQuad',
+        offset: '-=300'
+      });
   }
 
-  const drop = document.createElement('div');
-  drop.className = 'drop';
-  document.body.appendChild(drop);
-
-  const ripple = document.createElement('div');
-  ripple.className = 'ripple';
-  document.body.appendChild(ripple);
-
-  anime.timeline()
-    .add({
-      targets: drop,
-      translateY: ['-220', '65vh'],
-      duration: 800,
-      easing: 'easeOutBounce'
-    })
-    .add({
-      targets: title,
-      opacity: [0, 1],
-      filter: ['blur(10px)', 'blur(0px)'],
-      duration: 800,
-      easing: 'easeOutQuad',
-      offset: '-=200'
-    })
-    .add({
-      targets: drop,
-      opacity: [1, 0],
-      duration: 200,
-      easing: 'linear'
-    })
-    .add({
-      targets: ripple,
-      scale: [0, 20],
-      opacity: [0.6, 0],
-      duration: 1000,
-      easing: 'easeOutQuad',
-      offset: '-=600'
-    });
+  runAnimation();
+  logo.addEventListener('click', runAnimation);
 });

--- a/style.css
+++ b/style.css
@@ -5,8 +5,9 @@ html, body {
     margin: 0;
     padding: 0;
     overflow: hidden;
-    font-family: "Shizuru", "Noto Sans JP", sans-serif;
+    font-family: "Noto Serif JP", serif;
     color: #333;
+    font-weight: 200;
     background: #fff;
 }
 
@@ -29,12 +30,14 @@ html, body {
     justify-content: center;
     text-align: center;
     gap: 1rem;
+    opacity: 0;
 }
 
 .logo {
     width: 40%;
     max-width: 200px;
     height: auto;
+    cursor: pointer;
 }
 
 .store-name {
@@ -59,10 +62,10 @@ html, body {
 }
 
 .btn {
-    border: 1px solid #00A38C;
+    border: 1px solid #0000FF;
     border-radius: 4px;
     padding: 0.5rem;
-    color: #00A38C;
+    color: #0000FF;
     text-decoration: none;
     display: inline-flex;
     align-items: center;
@@ -71,7 +74,7 @@ html, body {
 }
 
 .btn:hover {
-    background: #00A38C;
+    background: #0000FF;
     color: #fff;
 }
 
@@ -105,27 +108,27 @@ body::before {
 }
 
 .drop {
-    width: 14px;
-    height: 14px;
+    width: 42px;
+    height: 42px;
     transform: translate(-50%, -220px);
 }
 
 .ripple {
-    width: 12px;
-    height: 12px;
-    top: calc(65vh - 6px);
+    width: 36px;
+    height: 36px;
+    top: calc(65vh - 18px);
     transform: translateX(-50%) scale(0);
     opacity: 0.6;
 }
 
 @keyframes drop {
     from { transform: translate(-50%, -220px); }
-    to { transform: translate(-50%, calc(65vh - 6px)); }
+    to { transform: translate(-50%, calc(65vh - 18px)); }
 }
 
 @keyframes ripple {
     from { transform: translateX(-50%) scale(0); opacity: 0.6; }
-    to { transform: translateX(-50%) scale(20); opacity: 0; }
+    to { transform: translateX(-50%) scale(60); opacity: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- slow the droplet fall and enlarge drop/ripple sizes
- hide the card until the ripple completes
- keep the logo click to rerun the animation

## Testing
- `node -v`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68775659d46083288350b386a98f3486