### PR TITLE
Add center ripple and hover labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,15 +31,15 @@
         </div>
         <div class="links">
             <!-- 予約サイト -->
-            <a href="https://beauty.hotpepper.jp/slnH000318020/" class="btn" aria-label="予約サイト">
+            <a href="https://beauty.hotpepper.jp/slnH000318020/" class="btn" aria-label="予約サイト" data-label="予約はこちら">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
             </a>
             <!-- MAP Info -->
-            <a href="https://beauty.hotpepper.jp/slnH000318020/map/" class="btn" aria-label="Map">
+            <a href="https://beauty.hotpepper.jp/slnH000318020/map/" class="btn" aria-label="Map" data-label="店舗情報はこちら">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"></polygon><line x1="8" y1="2" x2="8" y2="18"></line><line x1="16" y1="6" x2="16" y2="22"></line></svg>
             </a>
             <!-- Instagram -->
-            <a href="https://www.instagram.com/hair_design_space_ripple/" class="btn" aria-label="Instagram">
+            <a href="https://www.instagram.com/hair_design_space_ripple/" class="btn" aria-label="Instagram" data-label="Instagramはこちら">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
             </a>
         </div>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ window.addEventListener('DOMContentLoaded', () => {
   function runAnimation() {
     if (prefersReduced) {
       card.style.opacity = 1;
+      card.style.filter = 'none';
       title.style.opacity = 1;
       title.style.filter = 'none';
       return;
@@ -16,6 +17,7 @@ window.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.drop, .ripple').forEach(el => el.remove());
 
     card.style.opacity = 0;
+    card.style.filter = 'blur(10px)';
 
     const drop = document.createElement('div');
     drop.className = 'drop';
@@ -28,7 +30,7 @@ window.addEventListener('DOMContentLoaded', () => {
     anime.timeline()
       .add({
         targets: drop,
-        translateY: ['-220', '65vh'],
+        translateY: ['-220', '50vh'],
         duration: 1600,
         easing: 'easeOutBounce'
       })
@@ -50,8 +52,10 @@ window.addEventListener('DOMContentLoaded', () => {
       .add({
         targets: card,
         opacity: [0, 1],
-        duration: 500,
-        easing: 'easeOutQuad'
+        filter: ['blur(10px)', 'blur(0px)'],
+        duration: 800,
+        easing: 'easeOutQuad',
+        offset: '-=300'
       })
       .add({
         targets: title,

--- a/style.css
+++ b/style.css
@@ -30,6 +30,7 @@ html, body {
     text-align: center;
     gap: 1rem;
     opacity: 0;
+    filter: blur(10px);
 }
 
 .logo {
@@ -69,11 +70,35 @@ html, body {
     align-items: center;
     justify-content: center;
     transition: background 0.3s, color 0.3s;
+    position: relative;
 }
 
 .btn:hover {
     background: #00A38C;
     color: #fff;
+}
+
+.btn::after {
+    content: attr(data-label);
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 4px);
+    transform: translate(-50%, 10px);
+    background: #00A38C;
+    color: #fff;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s, transform 0.3s;
+    z-index: 1;
+}
+
+.btn:hover::after {
+    opacity: 1;
+    transform: translate(-50%, 0);
 }
 
 .icon {
@@ -114,14 +139,14 @@ body::before {
 .ripple {
     width: 36px;
     height: 36px;
-    top: calc(65vh - 18px);
+    top: calc(50vh - 18px);
     transform: translateX(-50%) scale(0);
     opacity: 0.6;
 }
 
 @keyframes drop {
     from { transform: translate(-50%, -220px); }
-    to { transform: translate(-50%, calc(65vh - 18px)); }
+    to { transform: translate(-50%, calc(50vh - 18px)); }
 }
 
 @keyframes ripple {


### PR DESCRIPTION
## Summary
- center the drop and ripple animations
- reveal the card and title during ripple expansion with blur fade
- add Japanese hover labels for action icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68776ad6657c832899384ae6bfae830e