### PR TITLE
Animate info and link sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@
 window.addEventListener('DOMContentLoaded', () => {
   const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const title = document.querySelector('.store-name');
+  const info = document.querySelector('.info');
+  const links = document.querySelector('.links');
   const card = document.querySelector('.card');
   const logo = document.querySelector('.logo');
 
@@ -11,6 +13,10 @@ window.addEventListener('DOMContentLoaded', () => {
       card.style.filter = 'none';
       title.style.opacity = 1;
       title.style.filter = 'none';
+      info.style.opacity = 1;
+      info.style.filter = 'none';
+      links.style.opacity = 1;
+      links.style.filter = 'none';
       return;
     }
 
@@ -18,6 +24,10 @@ window.addEventListener('DOMContentLoaded', () => {
 
     card.style.opacity = 0;
     card.style.filter = 'blur(10px)';
+    info.style.opacity = 0;
+    info.style.filter = 'blur(10px)';
+    links.style.opacity = 0;
+    links.style.filter = 'blur(10px)';
 
 
     const drop = document.createElement('div');
@@ -28,7 +38,7 @@ window.addEventListener('DOMContentLoaded', () => {
     ripple.className = 'ripple';
     document.body.appendChild(ripple);
 
-    anime.timeline()
+      anime.timeline()
       .add({
         targets: drop,
         translateY: ['-520', '50vh'],
@@ -57,14 +67,28 @@ window.addEventListener('DOMContentLoaded', () => {
         easing: 'easeOutQuad',
         offset: '-=300'
       })
-      .add({
-        targets: title,
-        opacity: [0, 1],
-        filter: ['blur(10px)', 'blur(0px)'],
-        duration: 800,
-        easing: 'easeOutQuad',
-        offset: '-=300'
-      });
+        .add({
+          targets: title,
+          opacity: [0, 1],
+          filter: ['blur(10px)', 'blur(0px)'],
+          duration: 800,
+          easing: 'easeOutQuad',
+          offset: '-=300'
+        })
+        .add({
+          targets: info,
+          opacity: [0, 1],
+          filter: ['blur(10px)', 'blur(0px)'],
+          duration: 800,
+          easing: 'easeOutQuad'
+        })
+        .add({
+          targets: links,
+          opacity: [0, 1],
+          filter: ['blur(10px)', 'blur(0px)'],
+          duration: 800,
+          easing: 'easeOutQuad'
+        });
   }
 
   runAnimation();

--- a/style.css
+++ b/style.css
@@ -122,6 +122,12 @@ body::before {
     filter: blur(10px);
 }
 
+.info,
+.links {
+    opacity: 0;
+    filter: blur(10px);
+}
+
 .drop,
 .ripple {
     position: absolute;
@@ -157,6 +163,11 @@ body::before {
 
 @media (prefers-reduced-motion: reduce) {
     .store-name {
+        opacity: 1;
+        filter: none;
+    }
+    .info,
+    .links {
         opacity: 1;
         filter: none;
     }


### PR DESCRIPTION
## Summary
- animate `.info` and `.links` after the store name
- keep reduced motion support for the new sections

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687776543544832898ebcc159f57dde1